### PR TITLE
Fixed bug when allocating cluster when current_cluster is not yet at end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ readme = "README.md"
 embedded-hal = "0.2.2"
 byteorder = { version = "1", default-features = false }
 nb = "0.1"
+log = "0.4"
+
+[dev-dependencies]
+env_logger = "0.7"

--- a/examples/create_test.rs
+++ b/examples/create_test.rs
@@ -110,6 +110,7 @@ impl TimeSource for Clock {
 }
 
 fn main() {
+    env_logger::init();
     let mut args = std::env::args().skip(1);
     let filename = args.next().unwrap_or("/dev/mmcblk0".into());
     let print_blocks = args.find(|x| x == "-v").map(|_| true).unwrap_or(false);

--- a/examples/test_mount.rs
+++ b/examples/test_mount.rs
@@ -113,6 +113,7 @@ impl TimeSource for Clock {
 }
 
 fn main() {
+    env_logger::init();
     let mut args = std::env::args().skip(1);
     let filename = args.next().unwrap_or("/dev/mmcblk0".into());
     let print_blocks = args.find(|x| x == "-v").map(|_| true).unwrap_or(false);

--- a/examples/write_test.rs
+++ b/examples/write_test.rs
@@ -155,7 +155,7 @@ fn main() {
             .unwrap();
 
         let buffer1 = b"\nFile Appended\n";
-        let buffer = [b'a'; 4096];
+        let buffer = [b'a'; 8192];
         println!("\nAppending to file");
         let num_written1 = controller.write(&mut volume, &mut f, &buffer1[..]).unwrap();
         let num_written = controller.write(&mut volume, &mut f, &buffer[..]).unwrap();

--- a/examples/write_test.rs
+++ b/examples/write_test.rs
@@ -109,6 +109,7 @@ impl TimeSource for Clock {
 }
 
 fn main() {
+    env_logger::init();
     let mut args = std::env::args().skip(1);
     let filename = args.next().unwrap_or_else(|| "/dev/mmcblk0".into());
     println!("Opening {:?}", filename);

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -789,7 +789,7 @@ impl Fat16Volume {
                 .read(&mut blocks, this_fat_block_num, "next_cluster")
                 .map_err(Error::DeviceError)?;
 
-            while this_fat_ent_offset < Block::LEN - 2 {
+            while this_fat_ent_offset <= Block::LEN - 2 {
                 let fat_entry = LittleEndian::read_u16(
                     &blocks[0][this_fat_ent_offset..=this_fat_ent_offset + 1],
                 );
@@ -1275,7 +1275,7 @@ impl Fat32Volume {
                 .read(&mut blocks, this_fat_block_num, "next_cluster")
                 .map_err(Error::DeviceError)?;
 
-            while this_fat_ent_offset < Block::LEN - 4 {
+            while this_fat_ent_offset <= Block::LEN - 4 {
                 let fat_entry = LittleEndian::read_u32(
                     &blocks[0][this_fat_ent_offset..=this_fat_ent_offset + 3],
                 ) & 0x0FFF_FFFF;

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use byteorder::{ByteOrder, LittleEndian};
 use core::convert::TryFrom;
+use log::{debug, trace, warn};
 
 pub(crate) const RESERVED_ENTRIES: u32 = 2;
 
@@ -771,10 +772,18 @@ impl Fat16Volume {
         let mut blocks = [Block::new()];
         let mut current_cluster = start_cluster;
         while current_cluster.0 < end_cluster.0 {
+            trace!(
+                "current_cluster={:?}, end_cluster={:?}",
+                current_cluster,
+                end_cluster
+            );
             let fat_offset = current_cluster.0 * 2;
+            trace!("fat_offset = {:?}", fat_offset);
             let this_fat_block_num = self.lba_start + self.fat_start.offset_bytes(fat_offset);
+            trace!("this_fat_block_num = {:?}", this_fat_block_num);
             let mut this_fat_ent_offset =
                 usize::try_from(fat_offset % Block::LEN_U32).map_err(|_| Error::ConversionError)?;
+            trace!("Reading block {:?}", this_fat_block_num);
             controller
                 .block_device
                 .read(&mut blocks, this_fat_block_num, "next_cluster")
@@ -791,6 +800,7 @@ impl Fat16Volume {
                 current_cluster += 1;
             }
         }
+        warn!("Out of space...");
         Err(Error::NotEnoughSpace)
     }
 
@@ -805,23 +815,49 @@ impl Fat16Volume {
         D: BlockDevice,
         T: TimeSource,
     {
+        debug!("Allocating new cluster, prev_cluster={:?}", prev_cluster);
         let end_cluster = Cluster(self.cluster_count + RESERVED_ENTRIES);
         let start_cluster = match self.next_free_cluster {
             Some(cluster) if cluster.0 < end_cluster.0 => cluster,
             _ => Cluster(RESERVED_ENTRIES),
         };
+        trace!(
+            "Finding next free between {:?}..={:?}",
+            start_cluster,
+            end_cluster
+        );
         let new_cluster = match self.find_next_free_cluster(controller, start_cluster, end_cluster)
         {
             Ok(cluster) => cluster,
             Err(_) if start_cluster.0 > RESERVED_ENTRIES => {
+                debug!(
+                    "Retrying, finding next free between {:?}..={:?}",
+                    Cluster(RESERVED_ENTRIES),
+                    end_cluster
+                );
                 self.find_next_free_cluster(controller, Cluster(RESERVED_ENTRIES), end_cluster)?
             }
             Err(e) => return Err(e),
         };
+        trace!(
+            "Found {:?}, updating in FAT to {:?}",
+            new_cluster,
+            Cluster::END_OF_FILE
+        );
         self.update_fat(controller, new_cluster, Cluster::END_OF_FILE)?;
         if let Some(cluster) = prev_cluster {
+            trace!(
+                "Updating old cluster {:?} to {:?} in FAT",
+                cluster,
+                new_cluster
+            );
             self.update_fat(controller, cluster, new_cluster)?;
         }
+        trace!(
+            "Finding next free between {:?}..={:?}",
+            new_cluster,
+            end_cluster
+        );
         self.next_free_cluster =
             match self.find_next_free_cluster(controller, new_cluster, end_cluster) {
                 Ok(cluster) => Some(cluster),
@@ -837,6 +873,7 @@ impl Fat16Volume {
                 }
                 Err(e) => return Err(e),
             };
+        debug!("Next free cluster is {:?}", self.next_free_cluster);
         if let Some(ref mut number_free_cluster) = self.free_clusters_count {
             *number_free_cluster -= 1;
         };
@@ -851,6 +888,7 @@ impl Fat16Volume {
                     .map_err(Error::DeviceError)?;
             }
         }
+        debug!("All done, returning {:?}", new_cluster);
         Ok(new_cluster)
     }
 
@@ -867,6 +905,7 @@ impl Fat16Volume {
         T: TimeSource,
     {
         while clusters_to_alloc > 0 {
+            debug!("Allocating clusters, left={:?}", clusters_to_alloc);
             let new_cluster = self.alloc_cluster(controller, prev_cluster, zero)?;
             prev_cluster = Some(new_cluster);
             clusters_to_alloc -= 1;
@@ -1205,7 +1244,6 @@ impl Fat32Volume {
         Ok(())
     }
 
-    // TODO write some tests
     /// Finds the next free cluster after the start_cluster and before end_cluster
     pub(crate) fn find_next_free_cluster<D, T>(
         &self,
@@ -1220,10 +1258,18 @@ impl Fat32Volume {
         let mut blocks = [Block::new()];
         let mut current_cluster = start_cluster;
         while current_cluster.0 < end_cluster.0 {
+            trace!(
+                "current_cluster={:?}, end_cluster={:?}",
+                current_cluster,
+                end_cluster
+            );
             let fat_offset = current_cluster.0 * 4;
+            trace!("fat_offset = {:?}", fat_offset);
             let this_fat_block_num = self.lba_start + self.fat_start.offset_bytes(fat_offset);
+            trace!("this_fat_block_num = {:?}", this_fat_block_num);
             let mut this_fat_ent_offset =
                 usize::try_from(fat_offset % Block::LEN_U32).map_err(|_| Error::ConversionError)?;
+            trace!("Reading block {:?}", this_fat_block_num);
             controller
                 .block_device
                 .read(&mut blocks, this_fat_block_num, "next_cluster")
@@ -1240,6 +1286,7 @@ impl Fat32Volume {
                 current_cluster += 1;
             }
         }
+        warn!("Out of space...");
         Err(Error::NotEnoughSpace)
     }
 
@@ -1316,6 +1363,7 @@ impl Fat32Volume {
         T: TimeSource,
     {
         while clusters_to_alloc > 0 {
+            debug!("Allocating clusters, left={:?}", clusters_to_alloc);
             let new_cluster = self.alloc_cluster(controller, prev_cluster, zero)?;
             prev_cluster = Some(new_cluster);
             clusters_to_alloc -= 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use core::convert::TryFrom;
+use log::debug;
 
 #[macro_use]
 mod structure;
@@ -175,6 +176,7 @@ where
     /// controller we can open volumes (partitions) and with those we can open
     /// files.
     pub fn new(block_device: D, timesource: T) -> Controller<D, T> {
+        debug!("Creating new embedded-sdmmc::Controller");
         Controller {
             block_device,
             timesource,
@@ -570,6 +572,10 @@ where
         file: &mut File,
         buffer: &[u8],
     ) -> Result<usize, Error<D::Error>> {
+        debug!(
+            "write(volume={:?}, file={:?}, buffer={:x?}",
+            volume, file, buffer
+        );
         if file.mode == Mode::ReadOnly {
             return Err(Error::ReadOnly);
         }
@@ -580,8 +586,10 @@ where
                 VolumeType::Fat32(fat) => fat.alloc_cluster(self, None, false)?,
             };
             file.entry.cluster = file.starting_cluster;
+            debug!("Alloc first cluster {:?}", file.starting_cluster);
         }
         if (file.current_cluster.1).0 < file.starting_cluster.0 {
+            debug!("Rewinding to start");
             file.current_cluster = (0, file.starting_cluster);
         }
         let bytes_until_max = usize::try_from(MAX_FILE_SIZE - file.current_offset)
@@ -590,56 +598,87 @@ where
         let mut written = 0;
 
         while written < bytes_to_write {
-            let mut current_cluster = file.current_cluster.clone();
+            let mut current_cluster = file.current_cluster;
+            debug!(
+                "Have written bytes {}/{}, finding cluster {:?}",
+                written, bytes_to_write, current_cluster
+            );
             let (block_idx, block_offset, block_avail) =
                 match self.find_data_on_disk(volume, &mut current_cluster, file.current_offset) {
-                    Ok(vars) => vars,
-                    Err(Error::EndOfFile) => match &mut volume.volume_type {
-                        VolumeType::Fat16(ref mut fat) => {
-                            match fat.alloc_cluster(self, Some(current_cluster.1), false) {
-                                Err(_) => return Ok(written),
-                                _ => (),
+                    Ok(vars) => {
+                        debug!(
+                            "Found block_idx={:?}, block_offset={:?}, block_avail={}",
+                            vars.0, vars.1, vars.2
+                        );
+                        vars
+                    }
+                    Err(Error::EndOfFile) => {
+                        debug!("Extending file");
+                        match &mut volume.volume_type {
+                            VolumeType::Fat16(ref mut fat) => {
+                                if fat
+                                    .alloc_cluster(self, Some(current_cluster.1), false)
+                                    .is_err()
+                                {
+                                    return Ok(written);
+                                }
+                                debug!("Allocated new FAT16 cluster, finding offsets...");
+                                let new_offset = self
+                                    .find_data_on_disk(
+                                        volume,
+                                        &mut current_cluster,
+                                        file.current_offset,
+                                    )
+                                    .map_err(|_| Error::AllocationError)?;
+                                debug!("New offset {:?}", new_offset);
+                                new_offset
                             }
-                            self.find_data_on_disk(
-                                volume,
-                                &mut current_cluster,
-                                file.current_offset,
-                            )
-                            .map_err(|_| Error::AllocationError)?
-                        }
-                        VolumeType::Fat32(ref mut fat) => {
-                            match fat.alloc_cluster(self, Some(current_cluster.1), false) {
-                                Err(_) => return Ok(written),
-                                _ => (),
+                            VolumeType::Fat32(ref mut fat) => {
+                                if fat
+                                    .alloc_cluster(self, Some(current_cluster.1), false)
+                                    .is_err()
+                                {
+                                    return Ok(written);
+                                }
+                                debug!("Allocated new FAT32 cluster, finding offsets...");
+                                let new_offset = self
+                                    .find_data_on_disk(
+                                        volume,
+                                        &mut current_cluster,
+                                        file.current_offset,
+                                    )
+                                    .map_err(|_| Error::AllocationError)?;
+                                debug!("New offset {:?}", new_offset);
+                                new_offset
                             }
-                            self.find_data_on_disk(
-                                volume,
-                                &mut current_cluster,
-                                file.current_offset,
-                            )
-                            .map_err(|_| Error::AllocationError)?
                         }
-                    },
+                    }
                     Err(e) => return Err(e),
                 };
             let mut blocks = [Block::new()];
-            self.block_device
-                .read(&mut blocks, block_idx, "read")
-                .map_err(Error::DeviceError)?;
-            let block = &mut blocks[0];
             let to_copy = core::cmp::min(block_avail, bytes_to_write - written);
+            if block_offset != 0 {
+                debug!("Partial block write");
+                self.block_device
+                    .read(&mut blocks, block_idx, "read")
+                    .map_err(Error::DeviceError)?;
+            }
+            let block = &mut blocks[0];
             block[block_offset..block_offset + to_copy]
                 .copy_from_slice(&buffer[written..written + to_copy]);
+            debug!("Writing block {:?}", block_idx);
             self.block_device
-                .write(&mut blocks, block_idx)
+                .write(&blocks, block_idx)
                 .map_err(Error::DeviceError)?;
             written += to_copy;
             file.current_cluster = current_cluster;
             let to_copy = i32::try_from(to_copy).map_err(|_| Error::ConversionError)?;
+            // TODO: Should we do this once when the whole file is written?
             file.update_length(file.length + (to_copy as u32));
             file.seek_from_current(to_copy).unwrap();
             file.entry.attributes.set_archive(true);
             file.entry.mtime = self.timesource.get_timestamp();
+            debug!("Updating FAT info sector");
             let fat_type = match &mut volume.volume_type {
                 VolumeType::Fat16(_) => FatType::Fat16,
                 VolumeType::Fat32(fat) => {
@@ -647,6 +686,7 @@ where
                     FatType::Fat32
                 }
             };
+            debug!("Updating dir entry");
             self.write_entry_to_disk(fat_type, &file.entry)?;
         }
         Ok(written)


### PR DESCRIPTION
Steps to reproduce:

1. Have file of 16384 bytes (32 clusters)
2. Open file with ReadWriteCreateOrAppend
3. Write to file.

Because opening the file and `file.seek_from_end(0)` does not update `file.current_cluster`, `alloc_cluster` will alloc a new cluster and attach it as the next cluster of the first cluster. This would effectively delete all the file contents following the first cluster.

Changed `find_data_on_disk` to actually seek to the next file cluster by using &mut, even when throwing errors. (Such as EndOfFile). I clone the current cluster because technically this gets updated for the file object after effectively writing the new block.

If desired I could provide with an `.img` file for this test case.