### PR TITLE
Added badges with links to crates.io and docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Embedded SD/MMC
+# Embedded SD/MMC [![crates.io](https://img.shields.io/crates/v/embedded-sdmmc.svg)](https://crates.io/crates/embedded-sdmmc) [![Documentation](https://docs.rs/embedded-sdmmc/badge.svg)](https://docs.rs/embedded-sdmmc)
 
 This crate is intended to allow you to read/write files on a FAT formatted SD
 card on your Rust Embedded device, as easily as using the `SdFat` Arduino


### PR DESCRIPTION
With this addition you can go to the crates.io and docs.rs pages for this crate.

From both you can get to this repo, so now there's a way back.